### PR TITLE
Refactor Docker setup for frontend deployment using Caddy

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -21,27 +21,17 @@ CMD ["npm", "run", "frontend:dev", "--", "--host", "0.0.0.0"]
 FROM base AS builder
 COPY apps/frontend ./apps/frontend
 COPY apps/backend ./apps/backend
-
 # Generate Prisma client for types
 RUN cd apps/backend && npx prisma generate
 # Build frontend
 RUN npm run build:frontend
 
-# Production stage - just a static files container (will be served by Caddy through a shared volume)
-FROM alpine:latest AS final
-COPY --from=builder /app/dist/apps/frontend /app
-
-# Create entrypoint script
-# NOTE this clean up is used because the share volume between caddy and frontend container is not cleaned on subseqent builds
-RUN echo '#!/bin/bash\n\
-echo "Cleaning app directory..."\n\
-rm -rf /app/*\n\
-echo "Copying new build files..."\n\
-cp -r /tmp/build/* /app/\n\
-echo "Build files updated successfully"\n\
-# Keep container running\n\
-tail -f /dev/null' > /entrypoint.sh && \
-chmod +x /entrypoint.sh
-
-WORKDIR /app
-ENTRYPOINT ["/entrypoint.sh"]
+# Production stage - using Caddy
+FROM caddy:2-alpine AS final
+COPY --from=builder /app/dist/apps/frontend /usr/share/caddy
+RUN printf ":80 {\n\
+    root * /usr/share/caddy\n\
+    try_files {path} /index.html\n\
+    file_server\n\
+}" > /etc/caddy/Caddyfile
+EXPOSE 80

--- a/docker/config/Caddyfile
+++ b/docker/config/Caddyfile
@@ -1,10 +1,6 @@
 {
     email {$ACME_EMAIL}
     admin off
-    # debug
-    # log {
-    #     level DEBUG
-    # }
 }
 
 {$DOMAIN} {
@@ -15,14 +11,10 @@
         reverse_proxy backend:3000 {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto {scheme}
-            header_up X-Forwarded-Host {host}
-            header_up X-Forwarded-Port {server_port}
         }
     }
 
-    # WebSocket endpoint - make it more specific
+    # WebSocket endpoint
     @websocket {
         path /ws*
         header Connection *Upgrade*
@@ -39,29 +31,12 @@
         }
     }
 
-    # Static file handling - make it the last handler
+    # Static file handling from frontend container
     handle {
-        root * /srv/frontend
+        reverse_proxy frontend:80 {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+        }
         encode gzip
-
-        # Cache static assets
-        @assets {
-            path /assets/*
-        }
-        header @assets {
-            Cache-Control "public, max-age=31536000"
-            # Prevent caching for development
-            ?no-cache "no-store, must-revalidate" {$NODE_ENV}==local
-        }
-
-        # Security headers
-        header {
-            X-Frame-Options "SAMEORIGIN"
-            X-XSS-Protection "1; mode=block"
-            X-Content-Type-Options "nosniff"
-        }
-
-        try_files {path} /index.html
-        file_server
     }
 }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
       - ./config/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
-      - frontend_static:/srv/frontend:ro
     environment:
       - DOMAIN=${DOMAIN:-localhost}
       - ACME_EMAIL=${ACME_EMAIL:-your@email.com}
@@ -79,8 +78,6 @@ services:
     environment:
       - VITE_APP_URL=${VITE_APP_URL}
       - NODE_ENV=${NODE_ENV:-local}
-    volumes:
-      - frontend_static:/app:ro
     depends_on:
       - backend
     networks:
@@ -90,7 +87,6 @@ volumes:
   postgres:
   caddy_data:
   caddy_config:
-  frontend_static:
 
 networks:
   app-network:


### PR DESCRIPTION
- Updated Dockerfile to use Caddy as the production server for serving frontend files instead of sharing a volume between the main Caddy and the frontend static files 
