### PR TITLE
Additional changes before Christmas games

### DIFF
--- a/apps/backend/src/modules/game/game.monitor.ts
+++ b/apps/backend/src/modules/game/game.monitor.ts
@@ -41,9 +41,8 @@ export class GameMonitor {
   
       const now = new Date();
       const gameTime = new Date(activeGame.commenceTime);
-      const fourHoursLater = new Date(gameTime.getTime() + GAME_DURATION);
   
-      if (now >= gameTime && now <= fourHoursLater) {
+      if (now >= gameTime && !activeGame.ended) {
         this.startPolling(activeGame);
         // Pull all TimeOdds for active game and set oddsHistory
         this.oddsHistory = await prisma.timeOdds.findMany({

--- a/apps/backend/src/modules/game/game.monitor.ts
+++ b/apps/backend/src/modules/game/game.monitor.ts
@@ -6,7 +6,6 @@ import { LeaderboardService } from '../leaderboard/leaderboard.service';
 
 const MONITOR_INTERVAL = 60000;
 const POLL_INTERVAL = 15000;
-const GAME_DURATION = 4 * 60 * 60 * 1000;
 
 const calculateTeamPrice = (
   currentWinProb: number | null,

--- a/apps/backend/src/modules/game/game.monitor.ts
+++ b/apps/backend/src/modules/game/game.monitor.ts
@@ -144,7 +144,7 @@ export class GameMonitor {
     // Process each position
     for (const position of activePositions) {
       const sellPrice = position.team === winningTeam 
-        ? Number(position.team === 'home' ? game.pregameHomePayout : game.pregameAwayPayout) / 100
+        ? Number(position.team === 'home' ? game.pregameHomePayout : game.pregameAwayPayout)
         : 0;
 
       const sellAmount = Number(position.buyAmount) * sellPrice / Number(position.buyPrice);
@@ -187,8 +187,8 @@ export class GameMonitor {
     // Broadcast final leaderboard
     await this.leaderboardService.calculateAndBroadcastLeaderboard(
       game.id,
-      winningTeam === 'home' ? Number(game.pregameHomePayout) / 100 : 0,
-      winningTeam === 'away' ? Number(game.pregameAwayPayout) / 100 : 0
+      winningTeam === 'home' ? Number(game.pregameHomePayout) : 0,
+      winningTeam === 'away' ? Number(game.pregameAwayPayout) : 0
     );
 
     // Broadcast game end event

--- a/apps/backend/src/modules/odds/odds.service.ts
+++ b/apps/backend/src/modules/odds/odds.service.ts
@@ -39,12 +39,18 @@ export const getOddsForGame = async (game: { sportKey: string; id: string; homeT
 
 export const getGameScore = async (game: { sportKey: string; id: string }) => {
   const apiKey = process.env.THE_ODDS_API_KEY;
-  const url = `https://api.the-odds-api.com/v4/sports/${game.sportKey}/scores?apiKey=${apiKey}&eventIds=${game.id.replace(/-/g, '')}&daysFrom=3`;
+  const baseUrl = `https://api.the-odds-api.com/v4/sports/${game.sportKey}/scores?apiKey=${apiKey}&eventIds=${game.id.replace(/-/g, '')}`;
   
   try {
-    const response = await axios.get(url);
-    const gameData = response.data[0];
+    // First try without daysFrom
+    let response = await axios.get(baseUrl);
     
+    // If no data found, try again with daysFrom=3
+    if (response.data.length === 0) {
+      response = await axios.get(`${baseUrl}&daysFrom=3`);
+    }
+
+    const gameData = response.data[0];
     if (!gameData) return null;
     
     return {
@@ -57,3 +63,112 @@ export const getGameScore = async (game: { sportKey: string; id: string }) => {
     return null;
   }
 };
+
+interface ESPNGame {
+  date: string;
+  name: string;
+  status: {
+    type: {
+      completed: boolean;
+    };
+  };
+  competitions: Array<{
+    competitors: Array<{
+      homeAway: string;
+      score: string;
+    }>;
+  }>;
+}
+
+const sportKeyToESPNMapping: Record<string, { sport: string; league: string }> = {
+  'americanfootball_ncaaf': { sport: 'football', league: 'college-football' },
+  'americanfootball_nfl': { sport: 'football', league: 'nfl' },
+  'basketball_nba': { sport: 'basketball', league: 'nba' },
+  'basketball_ncaab': { sport: 'basketball', league: 'mens-college-basketball' }
+};
+
+export const getGameScoreESPN = async (game: { 
+  sportKey: string; 
+  id: string; 
+  homeTeam: string;
+  awayTeam: string; 
+  commenceTime: Date 
+}) => {
+  try {
+    const espnMapping = sportKeyToESPNMapping[game.sportKey];
+    if (!espnMapping) {
+      console.warn(`No ESPN mapping found for sport key: ${game.sportKey}`);
+      return null;
+    }
+
+    // Convert game time to Eastern timezone and format as YYYYMMDD
+    const gameTimeEST = new Date(game.commenceTime).toLocaleString('en-US', { 
+      timeZone: 'America/New_York' 
+    });
+    const date = new Date(gameTimeEST)
+      .toISOString()
+      .split('T')[0]
+      .replace(/-/g, '');
+
+    const url = `https://site.api.espn.com/apis/site/v2/sports/${espnMapping.sport}/${espnMapping.league}/scoreboard?dates=${date}`;
+    
+    const response = await axios.get<{ events: ESPNGame[] }>(url);
+    const games = response.data.events;
+
+    if (!games || !games.length) return null;
+
+    // Expected event name format from our game data
+    const expectedName = `${game.awayTeam} at ${game.homeTeam}`.toLowerCase();
+
+    // Find matching game within 1 hour of commence time
+    const matchingGame = games.find((espnGame) => {
+      // Check if game time is within 1 hour
+      const espnDate = new Date(espnGame.date);
+      const commenceDate = new Date(game.commenceTime);
+      const hourDiff = Math.abs(espnDate.getTime() - commenceDate.getTime()) / 36e5;
+      
+      if (hourDiff > 1) return false;
+
+      // Check team names using fuzzy match
+      const espnName = espnGame.name.toLowerCase();
+      return fuzzyMatch(expectedName, espnName);
+    });
+
+    if (!matchingGame || !matchingGame.competitions?.[0]) return null;
+
+    const competition = matchingGame.competitions[0];
+    const homeTeam = competition.competitors.find(t => t.homeAway === 'home');
+    const awayTeam = competition.competitors.find(t => t.homeAway === 'away');
+
+    return {
+      completed: matchingGame.status.type.completed,
+      homeScore: homeTeam?.score,
+      awayScore: awayTeam?.score
+    };
+
+  } catch (error) {
+    console.error('Error fetching ESPN game scores:', error);
+    // Return null so the system can fall back to the original getGameScore
+    return null;
+  }
+};
+
+// Simple fuzzy matching function that allows for some variation in team names
+function fuzzyMatch(str1: string, str2: string): boolean {
+  // Remove common words and special characters
+  const clean = (s: string) => s.replace(/at|vs\.?|\s+/g, '').replace(/[^a-z0-9]/g, '');
+  const s1 = clean(str1);
+  const s2 = clean(str2);
+  
+  // Check if one string contains most of the other
+  const longer = s1.length > s2.length ? s1 : s2;
+  const shorter = s1.length > s2.length ? s2 : s1;
+  
+  let matches = 0;
+  for (let i = 0; i < shorter.length; i++) {
+    if (longer.includes(shorter[i])) matches++;
+  }
+  
+  // Return true if at least 80% of characters match
+  return matches / shorter.length >= 0.8;
+}

--- a/apps/backend/src/modules/websocket/websocket.service.ts
+++ b/apps/backend/src/modules/websocket/websocket.service.ts
@@ -14,6 +14,17 @@ export class WebSocketService {
   private async setupWebSocket() {
     this.fastify.get('/ws', { websocket: true }, async (connection) => {
       this.connections.add(connection);
+
+      connection.socket.on('message', (message: Buffer) => {
+        try {
+          const data = JSON.parse(message.toString());
+          if (data.type === 'ping') {
+            connection.socket.send(JSON.stringify({ type: 'pong' }));
+          }
+        } catch (error) {
+          console.error('Error handling websocket message:', error);
+        }
+      });
       
       // Get active game and its odds history
       const activeGame = await prisma.game.findFirst({

--- a/apps/frontend/src/app/app.tsx
+++ b/apps/frontend/src/app/app.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { trpc } from '../utils/trpc';
 import { useQueryTrpcClient } from './useQueryClient';
@@ -26,6 +26,7 @@ export function App() {
       <QueryClientProvider client={queryClient}>
         <AuthVerify />
         <Routes>
+          <Route path="/" element={<Navigate to="/sign-up" replace />} />
           <Route path="/sign-up" element={<SignUpPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/forgot-password" element={<ForgotPasswordPage />} />

--- a/apps/frontend/src/components/Auth/AuthHeader/AuthHeader.tsx
+++ b/apps/frontend/src/components/Auth/AuthHeader/AuthHeader.tsx
@@ -1,20 +1,12 @@
 import { useGlobalStateStore } from '@GlobalState';
 import AuthHeaderUI from './AuthHeaderUI';
-import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
+import { useLogout } from '@/hooks/useLogout';
 
 const AuthHeader = () => {
   const state = useGlobalStateStore((state) => state);
-  const navigate = useNavigate();
+  const handleLogout = useLogout();
 
-  const handleSignOut = () => {
-    state.signOut();
-    localStorage.removeItem('user');
-    toast.info('Signed out');
-    navigate('/');
-  };
-
-  return <AuthHeaderUI user={state.user} handleSignOut={handleSignOut} />;
+  return <AuthHeaderUI user={state.user} handleSignOut={handleLogout} />;
 };
 
 export default AuthHeader;

--- a/apps/frontend/src/components/Auth/AuthVerify.tsx
+++ b/apps/frontend/src/components/Auth/AuthVerify.tsx
@@ -1,7 +1,7 @@
 import { useGlobalStateStore } from '@GlobalState';
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import { toast } from 'react-toastify';
+import { useLogout } from '@/hooks/useLogout';
 
 const parseJwt = (token: string) => {
   try {
@@ -15,6 +15,29 @@ const AuthVerify = () => {
   const location = useLocation();
   const state = useGlobalStateStore((state) => state);
   const initialized = useRef(false);
+  const handleLogout = useLogout();
+
+  // Add global axios interceptor for 401 responses
+  useEffect(() => {
+    const interceptor = (response: Response) => {
+      if (response.status === 401) {
+        handleLogout();
+      }
+      return response;
+    };
+
+    // Add the interceptor to the global fetch
+    const originalFetch = window.fetch;
+    window.fetch = async (...args) => {
+      const response = await originalFetch(...args);
+      return interceptor(response.clone());
+    };
+
+    return () => {
+      // Restore original fetch when component unmounts
+      window.fetch = originalFetch;
+    };
+  }, [handleLogout]);
 
   useEffect(() => {
     if (initialized.current) return;
@@ -42,15 +65,13 @@ const AuthVerify = () => {
       if (user && user.accessToken) {
         const decodedJwt = parseJwt(user.accessToken);
         if (decodedJwt && decodedJwt.exp * 1000 < Date.now()) {
-          localStorage.removeItem('user');
-          toast.warning('Your token expired');
-          state.signOut();
+          handleLogout();
         }
       }
     } catch (error) {
       console.error('Error checking token:', error);
     }
-  }, [location, state]);
+  }, [location, handleLogout]);
 
   return null;
 };

--- a/apps/frontend/src/hooks/useLogout.ts
+++ b/apps/frontend/src/hooks/useLogout.ts
@@ -1,0 +1,18 @@
+import { useGlobalStateStore } from '@GlobalState';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+
+export const useLogout = () => {
+  const navigate = useNavigate();
+  const state = useGlobalStateStore((state) => state);
+
+  const handleLogout = () => {
+    localStorage.removeItem('user');
+    localStorage.removeItem('token');
+    state.signOut();
+    toast.info('Signed out');
+    navigate('/login');
+  };
+
+  return handleLogout;
+};

--- a/apps/frontend/src/hooks/useSignIn.ts
+++ b/apps/frontend/src/hooks/useSignIn.ts
@@ -1,0 +1,33 @@
+import { trpc } from '@utils/trpc';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { useGlobalStateStore } from '@GlobalState';
+
+export const useSignIn = () => {
+  const navigate = useNavigate();
+  const state = useGlobalStateStore((state) => state);
+
+  return trpc.auth.signIn.useMutation({
+    onSuccess: async ({ accessToken, email, role }) => {
+      try {
+        localStorage.setItem('token', accessToken);
+        const avatarUrl = 'https://images.unsplash.com/photo-1619946794135-5bc917a27793?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&fit=crop&h=200&w=200&s=b616b2c5b373a80ffc9636ba24f7a4a9';
+        const user = {
+          username: email,
+          role: role,
+          avatarUrl,
+        };
+        state.signIn(user);
+        localStorage.setItem('user', JSON.stringify({ ...user, accessToken }));
+        toast.success('Login successful!');
+        await new Promise(resolve => setTimeout(resolve, 0));
+        navigate('/game');
+      } catch (error) {
+        toast.error('Error during login');
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+};

--- a/apps/frontend/src/pages/Admin.tsx
+++ b/apps/frontend/src/pages/Admin.tsx
@@ -17,6 +17,7 @@ import {
 import logo from '@assets/logo.png';
 import { RouterOutput, trpc } from '@/utils/trpc';
 import { useNavigate } from 'react-router-dom';
+import { useLogout } from '@/hooks/useLogout';
 
 type Game = RouterOutput['admin']['getAvailableGames'][number];
 
@@ -45,6 +46,7 @@ const AdminPage = () => {
   const [games, setGames] = useState<Game[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
+  const logout = useLogout();
 
   const { data: activeGame, refetch: refetchActiveGame } = trpc.admin.getActiveGame.useQuery();
   const { mutate: setActiveGame } = trpc.admin.setActiveGame.useMutation({
@@ -157,6 +159,7 @@ const AdminPage = () => {
       <Button colorScheme="blue" onClick={() => navigate('/game')}>
         Return to Game
       </Button>
+      <Button colorScheme="blue" onClick={logout}>Logout</Button>
     </Box>
   );
 

--- a/apps/frontend/src/pages/Admin.tsx
+++ b/apps/frontend/src/pages/Admin.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   List,
   ListItem,
+  Flex,
   Input,
   Image,
   useToast, 
@@ -156,10 +157,12 @@ const AdminPage = () => {
 
   const HeaderButtons = () => (
     <Box position="absolute" top={4} right={4}>
-      <Button colorScheme="blue" onClick={() => navigate('/game')}>
-        Return to Game
-      </Button>
-      <Button colorScheme="blue" onClick={logout}>Logout</Button>
+      <Flex gap={2}>
+        <Button colorScheme="blue" onClick={() => navigate('/game')}>
+          Return to Game
+        </Button>
+        <Button colorScheme="blue" onClick={logout}>Logout</Button>
+      </Flex>
     </Box>
   );
 

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -59,7 +59,7 @@ const Header = () => (
   <Box textAlign="center" mt={6}>
     <Image src={logo} alt="AfterMarket Logo" boxSize="128px" mx="auto" />
     <Heading sx={gradientText} fontSize="4xl" fontWeight="extrabold">
-      AfterMarket Dashboard
+      The AfterMarket Game
     </Heading>
   </Box>
 );
@@ -437,7 +437,7 @@ const GamePage = () => {
         <VStack spacing={8}>
           <Header />
           <Text fontSize="lg" color="gray.300">
-            Live Tracking for {activeGame.homeTeam} vs. {activeGame.awayTeam}
+            Live Trading for {activeGame.homeTeam} vs. {activeGame.awayTeam}
           </Text>
 
           {!hasGameStarted && (

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -37,6 +37,7 @@ import { trpc } from '@/utils/trpc';
 import { useNavigate } from 'react-router-dom';
 import { Leaderboard, LeaderboardEntry } from '@/components/Leaderboard/Leaderboard';
 import { toast } from 'react-toastify';
+import { useLogout } from '@/hooks/useLogout';
 
 ChartJS.register(
   CategoryScale,
@@ -87,6 +88,7 @@ const GamePage = () => {
   const [lastPingTime, setLastPingTime] = useState<number | null>(null);
   const { isOpen: isBuyOpen, onOpen: onBuyOpen, onClose: onBuyClose } = useDisclosure();
   const { isOpen: isSellOpen, onOpen: onSellOpen, onClose: onSellClose } = useDisclosure();
+  const logout = useLogout();
   const { data: activeGame, refetch: refetchActiveGame } = trpc.admin.getActiveGame.useQuery();
   const { data: user } = trpc.users.getCurrentUser.useQuery();
   const { data: userGame, refetch: refetchUserGame, isLoading: isLoadingUserGame } = trpc.game.getUserGame.useQuery(
@@ -300,8 +302,13 @@ const GamePage = () => {
           </Button>
         )}
         <Button colorScheme="blue" onClick={() => {
-          // TODO: Implement logout logic
-          navigate('/login');
+          if (wsRef.current) {
+            wsRef.current.close();
+          }
+          if (pingIntervalRef.current) {
+            clearInterval(pingIntervalRef.current);
+          }
+          logout();
         }}>
           Logout
         </Button>

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -447,18 +447,6 @@ const GamePage = () => {
             </Box>
           )}
 
-          <Box textAlign="center" w="full" bg="gray.800" p={6} rounded="lg" mb={4}>
-            <Heading size="lg" color="green.400" mb={4}>Pregame Trade Values</Heading>
-            <VStack spacing={2}>
-              <Text color="gray.300">
-                Max value from $100 pregame trade on {activeGame.homeTeam}: ${(Number(activeGame.pregameHomePayout || 0)).toFixed(2)}
-              </Text>
-              <Text color="gray.300">
-                Max value from $100 pregame trade on {activeGame.awayTeam}: ${(Number(activeGame.pregameAwayPayout || 0)).toFixed(2)}
-              </Text>
-            </VStack>
-          </Box>
-
           {hasGameStarted && userGame && (
             <>
               {hasGameEnded && (
@@ -473,13 +461,6 @@ const GamePage = () => {
                 <Text fontSize="2xl" fontWeight="bold" color="blue.400">${availableBankroll}</Text>
               </Box>
 
-              <Box w="full" maxW="3xl" bg="gray.800" p={6} rounded="lg">
-                <Heading size="lg" color="green.400" textAlign="center" mb={4}>Live Odds Chart</Heading>
-                <Box h={["300px", "400px"]}>
-                  <Line data={chartData} options={chartOptions} />
-                </Box>
-              </Box>
-
               <Box w="full" maxW="3xl" bg="gray.800" p={6} rounded="lg" mb={4}>
                 <Heading size="lg" color="green.400" textAlign="center" mb={4}>Current Prices</Heading>
                 <Flex justify="space-around">
@@ -490,6 +471,25 @@ const GamePage = () => {
                     {activeGame.awayTeam}: ${awayPrice.toFixed(2)}
                   </Text>
                 </Flex>
+              </Box>
+
+              <Box w="full" maxW="3xl" bg="gray.800" p={6} rounded="lg">
+                <Heading size="lg" color="green.400" textAlign="center" mb={4}>Live Game Chart</Heading>
+                <Box h={["300px", "400px"]}>
+                  <Line data={chartData} options={chartOptions} />
+                </Box>
+              </Box>
+
+              <Box textAlign="center" w="full" bg="gray.800" p={6} rounded="lg" mb={4}>
+                <Heading size="lg" color="green.400" mb={4}>Pregame Trade Values</Heading>
+                <VStack spacing={2}>
+                  <Text color="gray.300">
+                    Max value from $100 pregame trade on {activeGame.homeTeam}: ${(Number(activeGame.pregameHomePayout || 0)).toFixed(2)}
+                  </Text>
+                  <Text color="gray.300">
+                    Max value from $100 pregame trade on {activeGame.awayTeam}: ${(Number(activeGame.pregameAwayPayout || 0)).toFixed(2)}
+                  </Text>
+                </VStack>
               </Box>
 
               <Flex gap={4} justifyContent="center">

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -472,40 +472,12 @@ const GamePage = () => {
                   </Text>
                 </Box>
               )}
-              <Box textAlign="center" w="full">
-                <Heading size="lg" color="green.400">Your Balance</Heading>
-                <Text fontSize="2xl" fontWeight="bold" color="blue.400">${availableBankroll}</Text>
-              </Box>
-
-              <Box w="full" maxW="3xl" bg="gray.800" p={6} rounded="lg" mb={4}>
-                <Heading size="lg" color="green.400" textAlign="center" mb={4}>Current Prices</Heading>
-                <Flex justify="space-around">
-                  <Text color="gray.300">
-                    {activeGame.homeTeam}: ${homePrice.toFixed(2)}
-                  </Text>
-                  <Text color="gray.300">
-                    {activeGame.awayTeam}: ${awayPrice.toFixed(2)}
-                  </Text>
-                </Flex>
-              </Box>
 
               <Box w="full" maxW="3xl" bg="gray.800" p={6} rounded="lg">
                 <Heading size="lg" color="green.400" textAlign="center" mb={4}>Live Game Chart</Heading>
                 <Box h={["300px", "400px"]}>
                   <Line data={chartData} options={chartOptions} />
                 </Box>
-              </Box>
-
-              <Box textAlign="center" w="full" bg="gray.800" p={6} rounded="lg" mb={4}>
-                <Heading size="lg" color="green.400" mb={4}>Pregame Trade Values</Heading>
-                <VStack spacing={2}>
-                  <Text color="gray.300">
-                    Max value from $100 pregame trade on {activeGame.homeTeam}: ${(Number(activeGame.pregameHomePayout || 0)).toFixed(2)}
-                  </Text>
-                  <Text color="gray.300">
-                    Max value from $100 pregame trade on {activeGame.awayTeam}: ${(Number(activeGame.pregameAwayPayout || 0)).toFixed(2)}
-                  </Text>
-                </VStack>
               </Box>
 
               <Flex gap={4} justifyContent="center">
@@ -526,6 +498,35 @@ const GamePage = () => {
                   Sell
                 </Button>
               </Flex>
+
+              <Box w="full" maxW="3xl" bg="gray.800" p={6} rounded="lg" mb={4}>
+                <Heading size="lg" color="green.400" textAlign="center" mb={4}>Current Prices</Heading>
+                <Flex justify="space-around">
+                  <Text color="gray.300">
+                    {activeGame.homeTeam}: ${homePrice.toFixed(2)}
+                  </Text>
+                  <Text color="gray.300">
+                    {activeGame.awayTeam}: ${awayPrice.toFixed(2)}
+                  </Text>
+                </Flex>
+              </Box>
+
+              <Box textAlign="center" w="full" bg="gray.800" p={6} rounded="lg" mb={4}>
+                <Heading size="lg" color="green.400" mb={4}>Pregame Trade Values</Heading>
+                <VStack spacing={2}>
+                  <Text color="gray.300">
+                    Max value from $100 pregame trade on {activeGame.homeTeam}: ${(Number(activeGame.pregameHomePayout || 0)).toFixed(2)}
+                  </Text>
+                  <Text color="gray.300">
+                    Max value from $100 pregame trade on {activeGame.awayTeam}: ${(Number(activeGame.pregameAwayPayout || 0)).toFixed(2)}
+                  </Text>
+                </VStack>
+              </Box>
+
+              <Box textAlign="center" w="full">
+                <Heading size="lg" color="green.400">Your Balance</Heading>
+                <Text fontSize="2xl" fontWeight="bold" color="blue.400">${availableBankroll}</Text>
+              </Box>
 
               <Box w="full" bg="gray.800" p={6} rounded="lg">
                 <Heading size="lg" color="green.400" mb={4}>Your Positions</Heading>

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -1,9 +1,8 @@
 import { Box, Button, Container, Flex, FormControl, FormLabel, Heading, Image, Input, Link, Stack, Text, VStack, keyframes } from '@chakra-ui/react';
 import { useState } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
-import { trpc } from '@utils/trpc';
-import { toast } from 'react-toastify';
+import { Link as RouterLink } from 'react-router-dom';
 import logo from '@assets/logo.png';
+import { useSignIn } from '@/hooks/useSignIn';
 
 const pulseAnimation = keyframes`
   0% { opacity: 1; }
@@ -29,32 +28,9 @@ const gradientButton = {
 };
 
 const LoginPage = () => {
-  const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-
-  const signInMutation = trpc.auth.signIn.useMutation({
-    onSuccess: async ({ accessToken, email, role }) => {
-      try {
-        localStorage.setItem('token', accessToken);
-        const avatarUrl = 'https://images.unsplash.com/photo-1619946794135-5bc917a27793?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&fit=crop&h=200&w=200&s=b616b2c5b373a80ffc9636ba24f7a4a9';
-        const user = {
-          username: email,
-          role: role,
-          avatarUrl,
-        };
-        localStorage.setItem('user', JSON.stringify({ ...user, accessToken }));
-        toast.success('Login successful!');
-        await new Promise(resolve => setTimeout(resolve, 0)); // Let the storage operations complete
-        navigate('/game');
-      } catch (error) {
-        toast.error('Error during login');
-      }
-    },
-    onError: (error) => {
-      toast.error(error.message);
-    },
-  });
+  const signInMutation = useSignIn();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/frontend/src/pages/SignUp.tsx
+++ b/apps/frontend/src/pages/SignUp.tsx
@@ -1,9 +1,10 @@
 import { Box, Button, Container, Flex, FormControl, FormLabel, Heading, Image, Input, Link, Stack, Text, VStack, keyframes, Select } from '@chakra-ui/react';
 import { useState } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import { trpc } from '@utils/trpc';
 import { toast } from 'react-toastify';
 import logo from '@assets/logo.png';
+import { useSignIn } from '@/hooks/useSignIn';
 
 const pulseAnimation = keyframes`
   0% { opacity: 1; }
@@ -29,7 +30,6 @@ const gradientButton = {
 };
 
 const SignUpPage = () => {
-  const navigate = useNavigate();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [fullName, setFullName] = useState('');
@@ -37,11 +37,11 @@ const SignUpPage = () => {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [referralType, setReferralType] = useState('');
   const [referralName, setReferralName] = useState('');
+  const signInMutation = useSignIn();
 
   const createUserMutation = trpc.users.createUser.useMutation({
     onSuccess: () => {
-      toast.success('Account created successfully!');
-      navigate('/login');
+      signInMutation.mutate({ email, password });
     },
     onError: (error) => {
       toast.error(error.message);


### PR DESCRIPTION
- Stop using 4 hour estimate for game duration
- Correct game end cash out calculations
- Redirect website root '/' to '/sign-up'
- Update game page title and subtitle to "The AfterMarket Game" and "Live Trading ..."
- Update pregame odds and win probabilities at start of game so that graph starts at $100/$100
- Rearrange game page sections to have chart up top and $ data underneath
- Use heartbeat ping instead of visibility change to maintain ws connection
- Implement proper logout functionality, add logout button to admin page
- Auto-login after signup
- Use ESPN to check game score in addition to odds api (should be faster to mark FINAL)